### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 EXPOSE 8555
 EXPOSE 8444


### PR DESCRIPTION
I suggest pinning the version to 20.04 which is latest Ubuntu version. This will prevent unwanted versions popping up in latest tag which can break the build