### PR TITLE
Fix path example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 ## Basic Startup
 ```
 docker run --name <container-name> -d ghcr.io/chia-network/chia:latest
-(optional -v /path/to/plots:plots)
+(optional -v /path/to/plots:/plots)
 ```
 
 ## Configuration


### PR DESCRIPTION
Path example should pass to the `/plots` directory inside the container.  Add the leading `/` to have full correct docker syntax.