### PR TITLE
Add tzdata to the installed utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV testnet="false"
 ENV full_node_port="null"
 ARG BRANCH
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl jq python3 ansible tar bash ca-certificates git openssl unzip wget python3-pip sudo acl build-essential python3-dev python3.8-venv python3.8-distutils apt nfs-common python-is-python3 vim
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y curl jq python3 ansible tar bash ca-certificates git openssl unzip wget python3-pip sudo acl build-essential python3-dev python3.8-venv python3.8-distutils apt nfs-common python-is-python3 vim tzdata
 
 RUN echo "cloning ${BRANCH}"
 RUN git clone --branch ${BRANCH} https://github.com/Chia-Network/chia-blockchain.git \


### PR DESCRIPTION
Install tzdata so that timezone can be set for the container with the TZ variable.
That would allow for consistent timestamps between logs when the container is run in conjunction with other machines which have the relevant timezone (e.g. container running the harvester, another machine running a full-node)
Resolves #49 