### PR TITLE
Fix timezone configuration via TZ variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ ENV farmer_address="null"
 ENV farmer_port="null"
 ENV testnet="false"
 ENV full_node_port="null"
+ENV TZ="UTC"
 ARG BRANCH
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq python3 ansible tar bash ca-certificates git openssl unzip wget python3-pip sudo acl build-essential python3-dev python3.8-venv python3.8-distutils apt nfs-common python-is-python3 vim tzdata
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN dpkg-reconfigure -f noninteractive tzdata
 
 RUN echo "cloning ${BRANCH}"
 RUN git clone --branch ${BRANCH} https://github.com/Chia-Network/chia-blockchain.git \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,8 @@
+if [[ -n "${TZ}" ]]; then
+  echo "Setting timezone to ${TZ}"
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+fi
+
 cd /chia-blockchain
 
 . ./activate

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,11 @@
 docker run --name <container-name> -d ghcr.io/chia-network/chia:latest
 (optional -v /path/to/plots:/plots)
 ```
-
+#### set the timezone for the container (optional, defaults to UTC)
+Timezones can be configured using the `TZ` env variable. A list of supported time zones can be found [here](http://manpages.ubuntu.com/manpages/focal/man3/DateTime::TimeZone::Catalog.3pm.html)
+```
+-e TZ="America/Chicago"
+```
 ## Configuration
 
 You can modify the behavior of your Chia container by setting specific environment variables.


### PR DESCRIPTION
The latest timezone additions to this repo actually break the build and keep it from working. This pull request fixes the issue and allows configuration of the timezone via the TZ variable:
`-e TZ="America/Chicago"`

The following link provides an overview of possible TZ values:
http://manpages.ubuntu.com/manpages/focal/man3/DateTime::TimeZone::Catalog.3pm.html