### PR TITLE
ca copy and import for remote harvester

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,13 @@ chia init
 if [[ ${keys} == "generate" ]]; then
   echo "to use your own keys pass them as a text file -v /path/to/keyfile:/path/in/container and -e keys=\"/path/in/container\""
   chia keys generate
+elif [[ ${keys} == "copy" ]]; then
+  if [[ -z ${ca}; then
+    echo "A path to a copy of the farmer peer's ssl/ca required."
+	exit
+  else
+  chia init -c ${ca}
+  fi
 else
   chia keys add -f ${keys}
 fi
@@ -24,8 +31,8 @@ sed -i 's/localhost/127.0.0.1/g' ~/.chia/mainnet/config/config.yaml
 if [[ ${farmer} == 'true' ]]; then
   chia start farmer-only
 elif [[ ${harvester} == 'true' ]]; then
-  if [[ -z ${farmer_address} || -z ${farmer_port} ]]; then
-    echo "A farmer peer address and port are required."
+  if [[ -z ${farmer_address} || -z ${farmer_port} || -z ${ca} ]]; then
+    echo "A farmer peer address, port, and ca path are required."
     exit
   else
     chia configure --set-farmer-peer ${farmer_address}:${farmer_port}

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ To start a farmer only node pass
 
 To start a harvester only node pass
 ```
--e harvester="true" -e farmer_address="addres.of.farmer" -e farmer_port="portnumber"
+-e harvester="true" -e farmer_address="addres.of.farmer" -e farmer_port="portnumber" -v /path/to/ssl/ca:/path/in/container -e ca="/path/in/container" -e keys="copy"
 ```
 
 The `plots_dir` environment variable can be used to specify the directory containing the plots, it supports PATH-style colon-separated directories.


### PR DESCRIPTION
Creates a "copy" function in keys to set path for the ssl/ca from the main farmer and init from the copy, updated readme.md to note syntax