### PR TITLE
Gracefully shutdown chia on signals.

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -15,9 +15,9 @@ else
   chia start farmer
 fi
 
-trap "chia stop all -d; exit 0" SIGINT SIGKILL SIGTERM
+trap "chia stop all -d; exit 0" SIGINT SIGTERM
 
 # Ensures the log file actually exists, so we can tail successfully
 touch "$CHIA_ROOT/log/debug.log"
 tail -f "$CHIA_ROOT/log/debug.log" &
-while true; do sleep 30; done
+while true; do sleep 1; done

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -15,6 +15,9 @@ else
   chia start farmer
 fi
 
+trap "chia stop all -d; exit 0" SIGINT SIGKILL SIGTERM
+
 # Ensures the log file actually exists, so we can tail successfully
 touch "$CHIA_ROOT/log/debug.log"
-tail -f "$CHIA_ROOT/log/debug.log"
+tail -f "$CHIA_ROOT/log/debug.log" &
+while true; do sleep 30; done


### PR DESCRIPTION
Listen for sigint, sigterm, and sigkill and gracefully shutdown chia.

From limited empirical testing, this change only seems to affect signals in the context of the container (i.e. ctrl-c in the container) and not the docker daemon killing the container. Attempts were made to have chia shutdown gracefully when the daemon killed the container, but no reliable results were obtained. This attempt was further complicated by docker's timeout when killing containers as sometimes chia may take longer than docker's timeout to shutdown