### PR TITLE
Reduce final container image size using Docker build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN chmod 1777 /tmp
 RUN apt-get update -q
-RUN apt-get upgrade -qy
 RUN apt-get install -qy --no-install-recommends \
   bc \
   ca-certificates \
@@ -43,7 +42,6 @@ COPY --from=install /chia-blockchain /chia-blockchain
 
 RUN chmod 1777 /tmp && \
     apt-get update -q && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -qy && \
     python_version=$(ls /chia-blockchain/venv/lib) && \
     DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
       ${python_version}-distutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,10 @@ COPY --from=install /chia-blockchain /chia-blockchain
 RUN chmod 1777 /tmp && \
     apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -qy && \
+    python_version=$(ls /chia-blockchain/venv/lib) && \
     DEBIAN_FRONTEND=noninteractive apt-get install -qy --no-install-recommends \
-      python3.8-venv \
+      ${python_version}-distutils \
+      ${python_version}-venv \
       tzdata && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I don't mean to step on any toes here, but I also haven't seen any movement on #88 for a while, so I thought I'd throw this out for consideration. Feel free to do whatever with it.

I tested python version install trick on Ubuntu 18.04, 21.04, and latest container images and all of them built and successfully ran the harvester, so it seems reasonably stable.