### PR TITLE
Use tail -F instead of -f.

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -19,5 +19,5 @@ trap "chia stop all -d; exit 0" SIGINT SIGTERM
 
 # Ensures the log file actually exists, so we can tail successfully
 touch "$CHIA_ROOT/log/debug.log"
-tail -f "$CHIA_ROOT/log/debug.log" &
+tail -F "$CHIA_ROOT/log/debug.log" &
 while true; do sleep 1; done


### PR DESCRIPTION
This ensures the tail doesn't break on log rotation when the file is
replaced.

- By default `-f/--follow` follows by descriptor and not file name.
- `-F` instead uses `--follow=name --retry` which keeps the follow on the
  named `debug.log` instead of on `debug.log.1` as soon as rotation happens.