### PR TITLE
Allow more precise control over started chia services via `service` env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ EXPOSE 8555 8444
 
 ENV CHIA_ROOT=/root/.chia/mainnet
 ENV keys="generate"
-ENV harvester="false"
-ENV farmer="false"
+ENV service="farmer"
 ENV plots_dir="/plots"
 ENV farmer_address=
 ENV farmer_port=
@@ -30,6 +29,10 @@ ENV testnet="false"
 ENV TZ="UTC"
 ENV upnp="true"
 ENV log_to_file="true"
+
+# Deprecated legacy options
+ENV harvester="false"
+ENV farmer="false"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tzdata && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,4 +60,18 @@ else
   sed -i 's/log_stdout: true/log_stdout: false/g' "$CHIA_ROOT/config/config.yaml"
 fi
 
+# Map deprecated legacy startup options.
+if [[ ${farmer} == "true" ]]; then
+  service="farmer-only"
+elif [[ ${harvester} == "true" ]]; then
+  service="harvester"
+fi
+
+if [[ ${service} == "harvester" ]]; then
+  if [[ -z ${farmer_address} || -z ${farmer_port} || -z ${ca} ]]; then
+    echo "A farmer peer address, port, and ca path are required."
+    exit
+  fi
+fi
+
 exec "$@"

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC2154
-if [[ ${farmer} == 'true' ]]; then
-  chia start farmer-only
-elif [[ ${harvester} == 'true' ]]; then
-  if [[ -z ${farmer_address} || -z ${farmer_port} || -z ${ca} ]]; then
-    echo "A farmer peer address, port, and ca path are required."
-    exit
-  else
-    chia start harvester
-  fi
-else
-  chia start farmer
-fi
+chia start "${service}"
 
 trap "echo Shutting down ...; chia stop all -d; exit 0" SIGINT SIGTERM
 
+# shellcheck disable=SC2154
 if [[ ${log_to_file} == 'true' ]]; then
   # Ensures the log file actually exists, so we can tail successfully
   touch "$CHIA_ROOT/log/debug.log"

--- a/readme.md
+++ b/readme.md
@@ -74,14 +74,14 @@ You can persist whole db and configuration, simply mount it to Host.
 
 To start a farmer only node pass
 ```bash
--e farmer="true"
+-e service="farmer-only"
 ```
 
 ### Harvester only
 
 To start a harvester only node pass
 ```bash
--e harvester="true" -e farmer_address="addres.of.farmer" -e farmer_port="portnumber" -v /path/to/ssl/ca:/path/in/container -e ca="/path/in/container" -e keys="copy"
+-e service="harvester" -e farmer_address="addres.of.farmer" -e farmer_port="portnumber" -v /path/to/ssl/ca:/path/in/container -e ca="/path/in/container" -e keys="copy"
 ```
 
 ### Plots
@@ -121,9 +121,9 @@ services:
       - 8444:8444
     environment:
       # Farmer Only
-#     - farmer=true
+#     - service=farmer-only
       # Harvester Only
-#     - harvester=true
+#     - service=harvester
 #     - farmer_address=192.168.0.10
 #     - farmer_port=8447
 #     - ca=/path/in/container

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ To start a farmer only node pass
 -e farmer="true"
 ```
 
-### Harverster only
+### Harvester only
 
 To start a harvester only node pass
 ```bash
@@ -88,7 +88,7 @@ To start a harvester only node pass
 
 The `plots_dir` environment variable can be used to specify the directory containing the plots, it supports PATH-style colon-separated directories.
 
-Or, you can cimply mount `/plots` path to your host machine.
+Or, you can simply mount `/plots` path to your host machine.
 
 ### Log level
 To set the log level to one of CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET


### PR DESCRIPTION
This PR introduces a `service` env variable in favour of the previous `farmer` and `harvester` options. This approach allows more precise control of which Chia services are started and now enables, for example, running `farmer-no-wallet` containers, or dedicated `wallet` or `wallet-only` containers.

(For some services, this will currently require maintaining and adjusting the config.yaml externally. Thus anything except the currently supported and documented `service=farmer`, `service=farmer-only`, `service=harvester` configurations are considered "expert only" and are not documented in the readme: you need to know what you're doing.)

The previous `farmer=true` and `harvester=true` startup options are still supported for backwards compatibility and translated to the new `service` variable. Documentation in the readme is adjusted accordingly.