### PR TITLE
Rewritten Dockerfile to use build-step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         lsb-release sudo
 
-RUN echo "cloning ${BRANCH}" && \
-    git clone --branch ${BRANCH} https://github.com/Chia-Network/chia-blockchain.git 
-
 WORKDIR /chia-blockchain
 
-RUN git submodule update --init mozilla-ca
-
-RUN echo "running build-script" && \
-    /bin/sh install.sh
+RUN echo "cloning ${BRANCH}" && \
+    git clone --branch ${BRANCH} --recurse-submodules=mozilla-ca https://github.com/Chia-Network/chia-blockchain.git . && \
+    echo "running build-script" && \
+    /bin/sh ./install.sh
 
 # IMAGE BUILD
 FROM python:3.9-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,28 @@
-FROM ubuntu:latest
+# CHIA BUILD STEP
+FROM python:3.9 AS chia_build
 
-EXPOSE 8555
-EXPOSE 8444
+RUN dpkg-reconfigure -f noninteractive tzdata
+
+ARG BRANCH=latest
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        lsb-release sudo
+
+RUN echo "cloning ${BRANCH}" && \
+    git clone --branch ${BRANCH} https://github.com/Chia-Network/chia-blockchain.git 
+
+WORKDIR /chia-blockchain
+
+RUN git submodule update --init mozilla-ca
+
+RUN echo "running build-script" && \
+    /bin/sh install.sh
+
+# IMAGE BUILD
+FROM python:3.9-slim
+
+EXPOSE 8555 8444
 
 ENV CHIA_ROOT=/root/.chia/mainnet
 ENV keys="generate"
@@ -15,18 +36,13 @@ ENV TZ="UTC"
 ENV upnp="true"
 ENV log_to_file="true"
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y bc curl lsb-release python3 tar bash ca-certificates git openssl unzip wget python3-pip sudo acl build-essential python3-dev python3.8-venv python3.8-distutils python-is-python3 vim tzdata && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tzdata && \
     rm -rf /var/lib/apt/lists/* && \
     ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone && \
     dpkg-reconfigure -f noninteractive tzdata
 
-ARG BRANCH=latest
-
-RUN echo "cloning ${BRANCH}" && \
-    git clone --branch ${BRANCH} https://github.com/Chia-Network/chia-blockchain.git && \
-    cd chia-blockchain && \
-    git submodule update --init mozilla-ca && \
-    /usr/bin/sh ./install.sh
+COPY --from=chia_build /chia-blockchain /chia-blockchain
 
 ENV PATH=/chia-blockchain/venv/bin:$PATH
 WORKDIR /chia-blockchain

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # CHIA BUILD STEP
 FROM python:3.9 AS chia_build
 
-RUN dpkg-reconfigure -f noninteractive tzdata
-
 ARG BRANCH=latest
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
As #88 and #118 have gone stale. I offer this PR for a more optimized image. While keeping the comments made by @cmmarslender in mind from both PRs, I aimed to just optimize the Dockerfile for a smaller image build and change any existing commands/functions/files as little as possible. 

The following changes have been made:
- Extracted the build from main image assembly to a separate build step.
- Used python:3.9-slim instead of ubuntu:latest for final image assembly
    - python:3.9-slim is based on debian:bullseye-slim and will accept current scripts as-is.
    - 3.9 is used as `install.sh` explicitly installs this version. Using :latest will result in errors on runtime.
- Reduced package installation in final image to only `tz-data`.

This has resulted in an image size reduction from:
- 600MB uncompressed / 241MB compressed
- 225MB uncompressed / 98MB compressed

Further optimizations can probably be made as I lack the deeper knowledge of image optimization.