### PR TITLE
Add possibility to set multiple services in "service" environment variable

### DIFF
--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -22,38 +22,42 @@ harvester_check=false
 wallet_check=false
 
 # Determine which services to healthcheck based on ${service}
-# shellcheck disable=SC2154
-case "${service}" in
-    all)
-        node_check=true
-        farmer_check=true
-        harvester_check=true
-        wallet_check=true
-    ;;
-    node)
-        node_check=true
-    ;;
-    harvester)
-        harvester_check=true
-    ;;
-    farmer)
-        node_check=true
-        farmer_check=true
-        harvester_check=true
-        wallet_check=true
-    ;;
-    farmer-no-wallet)
-        node_check=true
-        farmer_check=true
-        harvester_check=true
-    ;;
-    farmer-only)
-        farmer_check=true
-    ;;
-    wallet)
-        wallet_check=true
-    ;;
-esac
+# shellcheck disable=SC2154,SC2206
+services_array=($service)
+for option in "${services_array[@]}"
+do
+    case "${option}" in
+        all)
+            node_check=true
+            farmer_check=true
+            harvester_check=true
+            wallet_check=true
+        ;;
+        node)
+            node_check=true
+        ;;
+        harvester)
+            harvester_check=true
+        ;;
+        farmer)
+            node_check=true
+            farmer_check=true
+            harvester_check=true
+            wallet_check=true
+        ;;
+        farmer-no-wallet)
+            node_check=true
+            farmer_check=true
+            harvester_check=true
+        ;;
+        farmer-only)
+            farmer_check=true
+        ;;
+        wallet)
+            wallet_check=true
+        ;;
+    esac
+done
 
 
 if [[ ${node_check} == "true" ]]; then

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC2154
-chia start "${service}"
+# shellcheck disable=SC2154,SC2086
+chia start ${service}
 
 trap "echo Shutting down ...; chia stop all -d; exit 0" SIGINT SIGTERM
 


### PR DESCRIPTION
This change will allow "service" variable to take multiple options and function in the same way as "chia start" command.
For example, it will be possible to start container with -e service="farmer-only harvester wallet" to start only chosen services - farmer, harvester and wallet in this case. This was previously not possible without entrypoint overriding.
Unfortunately, there are some configurations that require more than single "chia start" option to start all required services without triggering node startup.