### PR TITLE
Change dev image path

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/chia-network/chia-dev
+            ghcr.io/chia-network/chia/dev
           tags: |
             type=raw,value=${{ github.event.inputs.sha }}
 


### PR DESCRIPTION
GitHub's image registry does not allow hyphen suffixes (eg. `-dev`.) But it does allow adding onto the path (eg. `/dev`.)