### PR TITLE
Add Docker build target for container that doesn't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,7 @@ COPY --chown=chia:chia --from=chia_build /chia-blockchain /chia-blockchain
 ENV PATH=/chia-blockchain/venv/bin:$PATH
 WORKDIR /chia-blockchain
 
-COPY docker-start.sh /usr/local/bin/
-COPY docker-entrypoint.sh /usr/local/bin/
-COPY docker-healthcheck.sh /usr/local/bin/
+COPY docker-start.sh docker-entrypoint.sh docker-healthcheck.sh /usr/local/bin/
 
 HEALTHCHECK --interval=1m --timeout=10s --start-period=20m \
   CMD /bin/bash /usr/local/bin/docker-healthcheck.sh || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     dpkg-reconfigure -f noninteractive tzdata && \
     groupadd -g "${GID}" chia && \
     useradd -m -u "${UID}" -g "${GID}" chia && \
-    chown -R chia:chia /home/chia
+    mkdir /plots && \
+    chown -R chia:chia /home/chia /plots
 
 COPY --chown=chia:chia --from=chia_build /chia-blockchain /chia-blockchain
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ RUN echo "cloning ${BRANCH}" && \
     /bin/sh ./install.sh
 
 # IMAGE BUILD
-FROM python:3.9-slim
+FROM python:3.9-slim AS no-root
+
+ARG UID=1000
+ARG GID=1000
 
 EXPOSE 8555 8444
 
-ENV CHIA_ROOT=/root/.chia/mainnet
+ENV CHIA_ROOT=/home/chia/.chia/mainnet
 ENV keys="generate"
 ENV service="farmer"
 ENV plots_dir="/plots"
@@ -43,12 +46,15 @@ ENV farmer="false"
 #   tzdata: Setting the timezone
 #   curl: Health-checks
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y sudo tzdata curl && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tzdata curl && \
     rm -rf /var/lib/apt/lists/* && \
     ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone && \
-    dpkg-reconfigure -f noninteractive tzdata
+    dpkg-reconfigure -f noninteractive tzdata && \
+    groupadd -g "${GID}" chia && \
+    useradd -m -u "${UID}" -g "${GID}" chia && \
+    chown -R chia:chia /home/chia
 
-COPY --from=chia_build /chia-blockchain /chia-blockchain
+COPY --chown=chia:chia --from=chia_build /chia-blockchain /chia-blockchain
 
 ENV PATH=/chia-blockchain/venv/bin:$PATH
 WORKDIR /chia-blockchain
@@ -60,5 +66,17 @@ COPY docker-healthcheck.sh /usr/local/bin/
 HEALTHCHECK --interval=1m --timeout=10s --start-period=20m \
   CMD /bin/bash /usr/local/bin/docker-healthcheck.sh || exit 1
 
+USER chia:chia
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["docker-start.sh"]
+
+FROM no-root
+
+USER root:root
+
+ENV CHIA_ROOT=/root/.chia/mainnet
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y sudo && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC2154
-if [[ -n "${TZ}" ]]; then
-  echo "Setting timezone to ${TZ}"
-  ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
-fi
-
 cd /chia-blockchain || exit 1
 
 # shellcheck disable=SC1091


### PR DESCRIPTION
#163 

Add a Dockerfile target `no-root` that will run chia blockchain binary as user/group `chia:chia` and does not have `sudo` installed. Final target in the Dockerfile allows building a container that runs as root and has `sudo`. People building the container can set the UID/GID that chia:chia will map to at build time. End users running the container must ensure that permissions work out properly for mounted directories in the chia:chia user/group if they are using the non-root container. This means either matching chia:chia's UID/GID with the host system user's UID/GID or modifying directory permissions on the host to allow read/writes by others (writes may be required for storing config files in a host-mounted directory)

New no-root version with UID/GID matching the current user can be built with `docker build -t <tags> --build-arg UID=$(id -u) --build-arg GID=$(id -g) --build-arg BRANCH=<target version> --target no-root -f Dockerfile .`