### PR TITLE
Install yq from image as build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN echo "cloning ${BRANCH}" && \
     echo "running build-script" && \
     /bin/sh ./install.sh
 
+# Get yq
+FROM mikefarah/yq:4.32.2 AS yq
+
 # IMAGE BUILD
 FROM python:3.9-slim
 
@@ -50,10 +53,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y sudo tzdata curl netcat && \
     rm -rf /var/lib/apt/lists/* && \
     ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone && \
-    dpkg-reconfigure -f noninteractive tzdata && \
-    curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq && \
-    chmod +x /usr/bin/yq
+    dpkg-reconfigure -f noninteractive tzdata
 
+COPY --from=yq /usr/bin/yq /usr/bin/yq
 COPY --from=chia_build /chia-blockchain /chia-blockchain
 
 ENV PATH=/chia-blockchain/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "cloning ${BRANCH}" && \
     /bin/sh ./install.sh
 
 # Get yq for chia config changes
-FROM mikefarah/yq:4.32.2 AS yq
+FROM mikefarah/yq:4 AS yq
 
 # IMAGE BUILD
 FROM python:3.9-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "cloning ${BRANCH}" && \
     echo "running build-script" && \
     /bin/sh ./install.sh
 
-# Get yq
+# Get yq for chia config changes
 FROM mikefarah/yq:4.32.2 AS yq
 
 # IMAGE BUILD


### PR DESCRIPTION
Easiest way to install yq in a container. To get yq with apt, we would need to install the `software-properties-common` package, adding that weight to the image. Another alternative would be to run a golang container as a build step, and build yq from source, and copy it over the same way we're doing now. This is basically that but with the binary prebuilt.

The upstream mikefarah/yq image is multi-arch, supporting amd64 and arm64
![image](https://user-images.githubusercontent.com/13720491/226980923-3a9607b6-929e-4cab-8f7f-855ed9432668.png)
