### PR TITLE
Remove undesired check for 'ca' when harvester

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -112,9 +112,16 @@ elif [[ ${harvester} == "true" ]]; then
 fi
 
 if [[ ${service} == "harvester" ]]; then
-  if [[ -z ${farmer_address} || -z ${farmer_port} || -z ${ca} ]]; then
-    echo "A farmer peer address, port, and ca path are required."
-    exit
+  if [[ ${keys} == "persistent" || ${keys} == "none" ]]; then
+    if [[ -z ${farmer_address} || -z ${farmer_port} ]]; then
+      echo "A farmer peer address and port are required."
+      exit
+    fi
+  else
+    if [[ -z ${farmer_address} || -z ${farmer_port} || -z ${ca} ]]; then
+      echo "A farmer peer address, port, and ca path are required."
+      exit
+    fi
   fi
 fi
 


### PR DESCRIPTION
It can be undesirable to initialise the keys for a harvester (identity on pool for example).

This adds an additional check to ignore the existence of the 'ca' variable if the keys are persistent or none.