### PR TITLE
Install timelord if service variable contains timelord

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -181,6 +181,11 @@ fi
 # Install timelord if service variable contains timelord substring
 if [ -z "${service##*timelord*}" ]; then
     echo "Installing timelord using install-timelord.sh"
+
+    # install-timelord.sh relies on lsb-release for determining the cmake installation method, and git for building chiavdf
+    DEBIAN_FRONTEND=noninteractive apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y lsb-release git
+    
     /bin/sh ./install-timelord.sh
 fi
 
@@ -199,3 +204,5 @@ if [[ ${service} == "harvester" ]]; then
 fi
 
 exec "$@"
+
+python -c 'import subprocess; id = subprocess.run(["lsb_release", "-is"], stdout=subprocess.PIPE); version = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(id.stdout.decode("ascii") == "Ubuntu\n" and float(version.stdout) < float(20.04))'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -159,17 +159,6 @@ else
   sed -i 's/log_stdout: true/log_stdout: false/g' "$CHIA_ROOT/config/config.yaml"
 fi
 
-# Install timelord if service variable contains timelord substring
-if [ -z "${service##*timelord*}" ]; then
-    echo "Installing timelord using install-timelord.sh"
-
-    # install-timelord.sh relies on lsb-release for determining the cmake installation method, and git for building chiavdf
-    DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y lsb-release git
-
-    /bin/sh ./install-timelord.sh
-fi
-
 # Compressed plot harvesting settings.
 if [[ -n "$parallel_decompressor_count" && "$parallel_decompressor_count" != 0 ]]; then
   yq -i '.harvester.parallel_decompressor_count = env(parallel_decompressor_count)' "$CHIA_ROOT/config/config.yaml"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -185,7 +185,7 @@ if [ -z "${service##*timelord*}" ]; then
     # install-timelord.sh relies on lsb-release for determining the cmake installation method, and git for building chiavdf
     DEBIAN_FRONTEND=noninteractive apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y lsb-release git
-    
+
     /bin/sh ./install-timelord.sh
 fi
 
@@ -204,5 +204,3 @@ if [[ ${service} == "harvester" ]]; then
 fi
 
 exec "$@"
-
-python -c 'import subprocess; id = subprocess.run(["lsb_release", "-is"], stdout=subprocess.PIPE); version = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(id.stdout.decode("ascii") == "Ubuntu\n" and float(version.stdout) < float(20.04))'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -178,6 +178,12 @@ else
   yq -i '.harvester.use_gpu_harvesting = False' "$CHIA_ROOT/config/config.yaml"
 fi
 
+# Install timelord if service variable contains timelord substring
+if [ -z "${service##*timelord*}" ]; then
+    echo "Installing timelord using install-timelord.sh"
+    /bin/sh ./install-timelord.sh
+fi
+
 # Map deprecated legacy startup options.
 if [[ ${farmer} == "true" ]]; then
   service="farmer-only"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -159,6 +159,17 @@ else
   sed -i 's/log_stdout: true/log_stdout: false/g' "$CHIA_ROOT/config/config.yaml"
 fi
 
+# Install timelord if service variable contains timelord substring
+if [ -z "${service##*timelord*}" ]; then
+    echo "Installing timelord using install-timelord.sh"
+
+    # install-timelord.sh relies on lsb-release for determining the cmake installation method, and git for building chiavdf
+    DEBIAN_FRONTEND=noninteractive apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y lsb-release git
+
+    /bin/sh ./install-timelord.sh
+fi
+
 # Compressed plot harvesting settings.
 if [[ -n "$parallel_decompressor_count" && "$parallel_decompressor_count" != 0 ]]; then
   yq -i '.harvester.parallel_decompressor_count = env(parallel_decompressor_count)' "$CHIA_ROOT/config/config.yaml"


### PR DESCRIPTION
Depends on: https://github.com/Chia-Network/chia-blockchain/pull/15828 -- merged, and is in the latest release.

Building this chia-docker image, install-timelord.sh succeeds, here's a quick benchmark ran from inside the container on my dev machine:

```
root@ee715dc08716:/chia-blockchain# ./vdf_bench square_asm 400000
Time: 2187 ms; n_slow: 74; speed: 182.8K ips
a = 0x6ce27bdb0240cadd4f5ba8eda519bfbe0ffd5ad3004ff27b9d6f65c62815265730bce32258434615674124e204f3c3429e6c214fd171846f5c0acf27c754ac42
b = -0x2040323dc47947c6161535b2e1366a274671d9bd1f9cb7644cb0da6b237a886a8414c9d9fa33f3fd9d9072b34561bc51e93ec1fbb341f6a18de5dd5c63fa421f
c = 0x78869cb37a6a7d392b19000ce9dc30358093871a2753ea79c0cabe40e283d1a2f60234c2f2f8777fde662a87f55a4cb7fea3489750e83c9cefff52fc594b19ab
```

Seems to work on Windows even with Docker Desktop (WSL2) so this might be a way of running a timelord on Windows until install-timelord.sh runs natively on Windows.