### PR TITLE
lowered cpu time needed to keep the container running

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -12,4 +12,4 @@ if [[ ${log_to_file} == 'true' ]]; then
   tail -F "$CHIA_ROOT/log/debug.log" &
 fi
 
-while true; do sleep 1; done
+tail -F /dev/null


### PR DESCRIPTION
`tail -F /dev/null` has the same effect as `while true ...` and keeps the container running.

`Tail` requires less cpu time and is therefore 'greener' in marketing terms.

Based on quick benchmark:
![grafik](https://github.com/Chia-Network/chia-docker/assets/1436672/943a2c20-305f-4b08-90c5-e378a8602a9a)
