### PR TITLE
Checks if chia needs to initialize from a defined CA

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,9 +15,9 @@ cd /chia-blockchain || exit 1
 chia ${chia_args} init --fix-ssl-permissions
 
 if [[ -n ${ca} ]]; then
-  openssl verify -CAfile ${ca}/private_ca.crt ${CHIA_ROOT}/config/ssl/harvester/private_harvester.crt &>/dev/null
-  if [ ${?} -ne 0 ]; then
+  if ! openssl verify -CAfile "${ca}/private_ca.crt" "${CHIA_ROOT}/config/ssl/harvester/private_harvester.crt" &>/dev/null; then
     echo "initializing from new CA"
+    # shellcheck disable=SC2086
     chia ${chia_args} init -c "${ca}"
   else
     echo "using existing CA"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,8 +15,13 @@ cd /chia-blockchain || exit 1
 chia ${chia_args} init --fix-ssl-permissions
 
 if [[ -n ${ca} ]]; then
-  # shellcheck disable=SC2086
-  chia ${chia_args} init -c "${ca}"
+  openssl verify -CAfile ${ca}/private_ca.crt ${CHIA_ROOT}/config/ssl/harvester/private_harvester.crt &>/dev/null
+  if [ ${?} -ne 0 ]; then
+    echo "initializing from new CA"
+    chia ${chia_args} init -c "${ca}"
+  else
+    echo "using existing CA"
+  fi
 fi
 
 # Enables whatever the default testnet is for the version of chia that is running


### PR DESCRIPTION
If a CA is passed to this container, the entrypoint script will run `chia init -c ${ca}` to generate certificates in `${CHIA_ROOT}/config/ssl` on startup. It currently does this even if you've already initiated from this CA in the past and kept the generated certs in a persistent volume. This just adds a simple openssl check to verify the private harvester cert in CHIA_ROOT against the supplied private CA.

For https://github.com/Chia-Network/chia-docker/issues/216