### PR TITLE
Quote booleans in docker-compose example to fix invalid syntax error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,9 +183,9 @@ services:
 #     keys: 
       TZ: ${TZ}
       # Enable UPnP
-#     upnp: true
+#     upnp: "true"
       # Enable log file generation
-#     log_to_file: true
+#     log_to_file: "true"
     volumes:
       - /path/to/plots:/plots
       - /home/user/.chia:/root/.chia


### PR DESCRIPTION
Fixes https://github.com/Chia-Network/chia-docker/issues/220.