### PR TITLE
Add uname check if service equals timelord

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -246,6 +246,13 @@ fi
 
 # Install timelord if service variable contains timelord substring
 if [ -z "${service##*timelord*}" ]; then
+    arch=$(uname -m)
+    echo "Info: detected CPU architecture $arch"
+    if [ "$arch" != "x86_64" ]; then
+      echo "Error: Unsupported CPU architecture for running the timelord component. Requires x86_64."
+      exit 1
+    fi
+
     echo "Installing timelord using install-timelord.sh"
 
     # install-timelord.sh relies on lsb-release for determining the cmake installation method, and git for building chiavdf


### PR DESCRIPTION
When running timelords in chia-docker, if you don't have an amd64 machine it can be confusing why chia_vdf compilation failed. This check makes the logs easier to understand what went wrong.