### PR TITLE
Add chia-tools to the image and run if chia. prefixed env is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     dpkg-reconfigure -f noninteractive tzdata
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
-COPY --from=chia-tools /chia-tools /chia-tools
+COPY --from=chia-tools /chia-tools /usr/bin/chia-tools
 COPY --from=chia_build /chia-blockchain /chia-blockchain
 
 ENV PATH=/chia-blockchain/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "cloning ${BRANCH}" && \
 
 # Get yq for chia config changes
 FROM mikefarah/yq:4 AS yq
+# Get chia-tools for a new experimental chia config management strategy
+FROM ghcr.io/chia-network/chia-tools:latest AS chia-tools
 
 # IMAGE BUILD
 FROM python:3.11-slim
@@ -61,6 +63,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     dpkg-reconfigure -f noninteractive tzdata
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
+COPY --from=chia-tools /chia-tools /chia-tools
 COPY --from=chia_build /chia-blockchain /chia-blockchain
 
 ENV PATH=/chia-blockchain/venv/bin:$PATH

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -302,7 +302,7 @@ fi
 # Check if any of the env vars start with "chia." or "chia__" and if so, process the config with chia-tools
 if env | grep -qE '^chia(\.|__)'; then
     echo "Found environment variables starting with 'chia.' or 'chia__' - Running chia-tools"
-    /chia-tools config edit "$CHIA_ROOT/config/config.yaml"
+    /usr/bin/chia-tools config edit "$CHIA_ROOT/config/config.yaml"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -297,4 +297,12 @@ if [[ ${service} == "harvester" ]]; then
   fi
 fi
 
+# EXPERIMENTAL!
+# If you use any of the chia tools config processing, your config will lose all yaml anchors and be fully expanded out
+# Check if any of the env vars start with "chia." or "chia__" and if so, process the config with chia-tools
+if env | grep -qE '^chia(\.|__)'; then
+    echo "Found environment variables starting with 'chia.' or 'chia__' - Running chia-tools"
+    /chia-tools config edit "$CHIA_ROOT/config/config.yaml"
+fi
+
 exec "$@"


### PR DESCRIPTION
Enables experimental support for editing config with chia-tools.

Any environment variables on the container that start with `chia.` will cause chia tools to run. Config values can then be set by doing things like `-e "chia.full_node.port=8444"`

Note that chia-tools does not currently retain yaml anchors, so the resulting config file will be completely expanded 